### PR TITLE
Deep merge custom tags

### DIFF
--- a/akami.gemspec
+++ b/akami.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "gyoku", ">= 0.4.0"
   s.add_dependency "nokogiri", ">= 1.4.0"
+  s.add_dependency "deep_merge", ">= 1.0.0"
 
   s.add_development_dependency "rake",    "~> 0.8.7"
   s.add_development_dependency "rspec",   "~> 2.5.0"

--- a/lib/akami/wsse.rb
+++ b/lib/akami/wsse.rb
@@ -98,7 +98,7 @@ module Akami
           }
         }
       elsif username_token?
-        Gyoku.xml wsse_username_token.merge!(hash)
+        Gyoku.xml wsse_username_token.deep_merge!(hash)
       elsif timestamp?
         Gyoku.xml wsu_timestamp.merge!(hash)
       else

--- a/lib/akami/wsse.rb
+++ b/lib/akami/wsse.rb
@@ -96,10 +96,10 @@ module Akami
           |key, v1, v2| v1.merge!(v2) {
             |key, v1, v2| v1.merge!(v2)
           }
-        }
+        }.deep_merge!(hash)
       elsif username_token?
         Gyoku.xml wsse_username_token.deep_merge!(hash)
-      elsif timestamp?
+      elsif timestamp? 
         Gyoku.xml wsu_timestamp.deep_merge!(hash)
       else
         ""

--- a/lib/akami/wsse.rb
+++ b/lib/akami/wsse.rb
@@ -100,7 +100,7 @@ module Akami
       elsif username_token?
         Gyoku.xml wsse_username_token.deep_merge!(hash)
       elsif timestamp?
-        Gyoku.xml wsu_timestamp.merge!(hash)
+        Gyoku.xml wsu_timestamp.deep_merge!(hash)
       else
         ""
       end

--- a/spec/akami/wsse_spec.rb
+++ b/spec/akami/wsse_spec.rb
@@ -224,7 +224,7 @@ describe Akami do
       end
     end
 
-    context "whith credentials and timestamp" do
+    context "with credentials and timestamp" do
       before do
         wsse.credentials "username", "password"
         wsse.timestamp = true
@@ -240,6 +240,9 @@ describe Akami do
 
       it "contains the username and password" do
         wsse.to_xml.should include("username", "password")
+        wsse["wsse:Security"]["wsse:UsernameToken"] = { "Organization" => "ACME" }
+        wsse.to_xml.should include("username", "password")
+        wsse.to_xml.should include("Organization")
       end
     end
   end

--- a/spec/akami/wsse_spec.rb
+++ b/spec/akami/wsse_spec.rb
@@ -129,6 +129,13 @@ describe Akami do
       it "contains the PasswordText type attribute" do
         wsse.to_xml.should include(Akami::WSSE::PASSWORD_TEXT_URI)
       end
+
+      it "doesn't overwrite the wsse:Security node when adding custom tags" do
+        wsse.to_xml.should include("username", "password")
+        wsse["wsse:Security"]["wsse:UsernameToken"] = { "Organization" => "ACME" }
+        wsse.to_xml.should include("username", "password")
+        wsse.to_xml.should include("Organization")
+      end
     end
 
     context "with credentials and digest auth" do

--- a/spec/akami/wsse_spec.rb
+++ b/spec/akami/wsse_spec.rb
@@ -188,6 +188,13 @@ describe Akami do
           wsse.to_xml.should include("<wsu:Expires>#{(created_at + 60).utc.xmlschema}</wsu:Expires>")
         end
       end
+
+      it "doesn't overwrite the wsu:Timestamp when adding custom tags" do
+        wsse.to_xml.should include('<wsu:Timestamp wsu:Id="Timestamp-1" ' + 'xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">')
+        wsse["wsse:Security"]["wsse:UsernameToken"] = { "Organization" => "ACME" }
+        wsse.to_xml.should include('<wsu:Timestamp wsu:Id="Timestamp-2" ' + 'xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">')
+        wsse.to_xml.should include("Organization")
+      end
     end
 
     context "with #created_at" do


### PR DESCRIPTION
I ran into an issue where I wanted to add some header elements to wsse:Security as [specified in the savon documentation](https://img.skitch.com/20120830-m5fw2374q36pqss7tqnig4uyt2.jpg).

But, when I [attempted that](https://img.skitch.com/20120830-bhbg84ygxjejqku2557bcw19y6.jpg), the wsse:Security elements were completely overwritten.

These commits ensure that a deep hash merge is used to retain custom tags.  

Please note that I didn't cover the case where a signature is present since there were no tests to work with and I'm not well versed in how such things should work.

I believe this resolves https://github.com/rubiii/savon/issues/233.
