### PR TITLE
Orders the wsu:Timestamp as the first element

### DIFF
--- a/lib/akami/wsse.rb
+++ b/lib/akami/wsse.rb
@@ -92,7 +92,7 @@ module Akami
       if signature? and signature.have_document?
         Gyoku.xml wsse_signature.merge!(hash)
       elsif username_token? && timestamp?
-        Gyoku.xml wsse_username_token.merge!(wsu_timestamp) {
+        Gyoku.xml wsu_timestamp.merge!(wsse_username_token) {
           |key, v1, v2| v1.merge!(v2) {
             |key, v1, v2| v1.merge!(v2)
           }

--- a/spec/akami/wsse_spec.rb
+++ b/spec/akami/wsse_spec.rb
@@ -203,6 +203,10 @@ describe Akami do
           wsse.to_xml.should include("<wsu:Expires>#{(created_at + 60).utc.xmlschema}</wsu:Expires>")
         end
       end
+
+      it "orders a wsu:Timestamp first" do
+        wsse.to_xml.should match(/<wsse:Security[^>]*>\s*<wsu:Timestamp/)
+      end
     end
 
     context "with #created_at" do
@@ -248,6 +252,10 @@ describe Akami do
 
       it "contains the username and password" do
         wsse.to_xml.should include("username", "password")
+      end
+
+      it "orders a wsu:Timestamp first" do
+        wsse.to_xml.should match(/<wsse:Security[^>]*>\s*<wsu:Timestamp/)
       end
     end
   end


### PR DESCRIPTION
I've been trying to use the Oracle Primavera P6 Web Services which was failing with Authentication errors. After much experimentation with SoapUI and a Java application I discovered the wsu:Timestamp element needed to be first for this web services.

I looked through the WSSE documentation for information on ordering elements but it isn't clear.  The first time I read it, it seemed to say the order didn't matter, then another part of the spec says the order should be as required for processing.  I'm guessing in the case of the Oracle Primavera P6 Web Services that means the wsu:Timestamp is needed first because if that is out of sync then nothing happens.

I was wondering if others have experienced this issue.  Also if this change breaks existing applications.
