### PR TITLE
Ignore blank nodes on signature verification

### DIFF
--- a/lib/akami/wsse/verify_signature.rb
+++ b/lib/akami/wsse/verify_signature.rb
@@ -14,7 +14,7 @@ module Akami
       attr_reader :document
 
       def initialize(xml)
-        @document = Nokogiri::XML(xml)
+        @document = Nokogiri::XML(xml.to_s, &:noblanks)
       end
 
       # Returns XML namespaces that are used internally for document querying.

--- a/spec/akami/wsse/verify_signature_spec.rb
+++ b/spec/akami/wsse/verify_signature_spec.rb
@@ -14,6 +14,12 @@ describe Akami::WSSE::VerifySignature do
     validator.verify!.should eq(true)
   end
 
+  it 'should validate correctly signed XML messages with whitespaces' do
+    xml = fixture('akami/wsse/verify_signature/valid_whitespaces.xml')
+    validator = described_class.new(xml)
+    expect(validator.verify!).to equal(true)
+  end
+
   it 'should not validate signed XML messages with digested content changed' do
     xml = fixture('akami/wsse/verify_signature/invalid_digested_changed.xml')
     validator = described_class.new(xml)

--- a/spec/fixtures/akami/wsse/verify_signature/valid_whitespaces.xml
+++ b/spec/fixtures/akami/wsse/verify_signature/valid_whitespaces.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:wsa="http://www.w3.org/2005/08/addressing">
+	<soap:Header>
+		<oasis:Security xmlns:oasis="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
+			<oasis:BinarySecurityToken ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3" EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary" wsu:Id="uuid-639b8970-7644-4f9e-9bc4-9c2e367808fc-1">MIIEZTCCA02gAwIBAgIJALaQmjuYuxpuMA0GCSqGSIb3DQEBBQUAMH4xCzAJBgNVBAYTAldXMRIwEAYDVQQIEwlXb3JsZHdpZGUxETAPBgNVBAcTCFhNTCBjaXR5MREwDwYDVQQKEwhTYXZvbi5yYjEhMB8GA1UECxMYQWthbWkgdGVzdGluZyBkZXBhcnRtZW50MRIwEAYDVQQDEwlBa2FtaSBHZW0wHhcNMTQwNjEwMDg1NjEzWhcNMjQwNjA3MDg1NjEzWjB+MQswCQYDVQQGEwJXVzESMBAGA1UECBMJV29ybGR3aWRlMREwDwYDVQQHEwhYTUwgY2l0eTERMA8GA1UEChMIU2F2b24ucmIxITAfBgNVBAsTGEFrYW1pIHRlc3RpbmcgZGVwYXJ0bWVudDESMBAGA1UEAxMJQWthbWkgR2VtMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvjKxq8WnYOT7ymrSNmN95NFMXhLxdumQz0QniRURVQ1P2sOwxOw9mlFnMsdGwsTYUJ9TwwBvA82UAaHEp/mMlHVc0oIKBzMWXj3qK3paRpcooh9hVSGlnqGep+/mzpP9SgPeJRXUgewnnXYsdPkV3k+EFLP/ZwGKOu3lTf4eTNm+TfnW4jHQYg2DpXHXtfV/H2mlDl/p/oUSoUnD3rWrF8IDPTSpy/30KtiY9ijy4RhllbSxM5Y230rpvlty1qqlNI/g34thL15nFaU/aIWQ/KwiCqthldd3m92S9gQ+iY4YtJkxAFsVAWT8gF32pmCKeH5IMmihZqlno6pUG0pIHwIDAQABo4HlMIHiMB0GA1UdDgQWBBQxpPv3f9MSv1y+BoR07lNRWi78ODCBsgYDVR0jBIGqMIGngBQxpPv3f9MSv1y+BoR07lNRWi78OKGBg6SBgDB+MQswCQYDVQQGEwJXVzESMBAGA1UECBMJV29ybGR3aWRlMREwDwYDVQQHEwhYTUwgY2l0eTERMA8GA1UEChMIU2F2b24ucmIxITAfBgNVBAsTGEFrYW1pIHRlc3RpbmcgZGVwYXJ0bWVudDESMBAGA1UEAxMJQWthbWkgR2VtggkAtpCaO5i7Gm4wDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQUFAAOCAQEAZphue2C31+5SpoZiIQav3xtwfIt+PRtK0ZN0w2ZxR1LmbWS9jX4elvwE5B5Yyu4UmjyvXGA6j9s5PGedXMabpi9GWsaEfHRKsF/TrH0KauhPrAWTuc1UxMFM5zPc6LeWJ8ofaVIgg4S4UFnf/fnkc/BtMMDCIyb62HkRmV+FqOOD+LlkcT701VKty68ubCg9xKaLg7L4zZBPYJrt0iLY2LWKh4ABinxfA1DFEVw9PVIEQKopwkO1A10rrKbfZqALQg5egVQypfVJ7E0Nkq5VeT3d3u3ybnZw/ZprQR0uPm+Ap492itLMMUX3iyJkxteAfT+03ztKWEsmGMbZpzG7VA==</oasis:BinarySecurityToken>
+			<Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+				<SignedInfo>
+					<CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+					<SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+					<Reference URI="#_779bc0e70903ff79e62739956a11c7e3584a9012">
+						<Transforms>
+							<Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+						</Transforms>
+						<DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+						<DigestValue>8yHW2c0jdon+cADkxk47/gLo0ps=</DigestValue>
+					</Reference>
+					<Reference URI="#_747c942c134dd275275707f2cf63e8de7881d367">
+						<Transforms>
+							<Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+						</Transforms>
+						<DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+						<DigestValue>eRsb4CWXD17hl5exQvaZYDnOQOM=</DigestValue>
+					</Reference>
+					<Reference URI="#_2dc10b4daca971ef4ddb482338ebd7ba30112e2a">
+						<Transforms>
+							<Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+						</Transforms>
+						<DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+						<DigestValue>1aznRVYGR81veFFG2lNU9WjUhDs=</DigestValue>
+					</Reference>
+					<Reference URI="#_1f546393fdadf04fd9afcf172658c78cfd1b735d">
+						<Transforms>
+							<Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+						</Transforms>
+						<DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+						<DigestValue>KXKU6ZFziN415Hd2K6WevzUihYs=</DigestValue>
+					</Reference>
+					<Reference URI="#_724554b8920321ee32020dac076be1f58d92d3c7">
+						<Transforms>
+							<Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+						</Transforms>
+						<DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+						<DigestValue>YrKqrE99N7hNGYEvrhifL/LaxKQ=</DigestValue>
+					</Reference>
+					<Reference URI="#uuid-639b8970-7644-4f9e-9bc4-9c2e367808fc-1">
+						<Transforms>
+							<Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+						</Transforms>
+						<DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+						<DigestValue>VevrJZBe3aVif18GuHIrSZz5my8=</DigestValue>
+					</Reference>
+				</SignedInfo>
+				<SignatureValue>
+					NEJTWOxr2IdWOyV+b1XjRU1Koaa0OYDbz0MqErcqjEgLt3rgK2YyZpg2yMBB++YmlwhS2Gm/Iqnyv6U909hvF4Hg+9/kw/FiwqhavcW+/N9HZKo0vGww/rU4qcKrNdU/lETQhxfk5DpKAoAUWV6yGxnbP8GzTXWGtP4sfLlcFjfOkTnePEM7QLjJLk9l2YkvbmyaRClj3psYrh0Fo1G+LWZ7W8UpaPzoo8e+s2EkKDAbchWoQJp2vEIhLnRRWDMuweRpsURigjbIkJCKnawmZ8SG1nA68nYa9jTh6824XVepxbkvtvNzEFC6dmZAjwAWhADf1+7lpqUyml/wZyHWRw==
+				</SignatureValue>
+				<KeyInfo>
+					<o:SecurityTokenReference>
+						<o:Reference ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3" URI="#uuid-639b8970-7644-4f9e-9bc4-9c2e367808fc-1"/>
+					</o:SecurityTokenReference>
+				</KeyInfo>
+			</Signature>
+		</oasis:Security>
+		<wsa:Action wsu:Id="_779bc0e70903ff79e62739956a11c7e3584a9012">SomeAction</wsa:Action>
+		<wsa:To wsu:Id="_747c942c134dd275275707f2cf63e8de7881d367">https://strict.endpoint/path</wsa:To>
+		<wsa:ReplyTo wsu:Id="_2dc10b4daca971ef4ddb482338ebd7ba30112e2a">
+			<wsa:Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:Address>
+		</wsa:ReplyTo>
+		<wsa:MessageID wsu:Id="_1f546393fdadf04fd9afcf172658c78cfd1b735d">SRV-0f687bbd-62503e99-926a4d3c-5dde443c-dbf6d68f</wsa:MessageID>
+	</soap:Header>
+	<soap:Body wsu:Id="_724554b8920321ee32020dac076be1f58d92d3c7">
+		<messageCode>code</messageCode>
+		<!-- Comments should be ignored during canonicalization -->
+		<message>message</message>
+	</soap:Body>
+</soap:Envelope>


### PR DESCRIPTION
Blank nodes in pretty print XML should be ignored on digest calculation.

This is probably should be done in canonicalization step, but Nokogiri doesn't perform it in it's `canonicalize` method (weird, why). So, I'm (re)parsing document with `NOBLANKS` option in initializer.
