### PR TITLE
Include xmlns:wsu attribute in wsse:Security tag.

### DIFF
--- a/lib/akami/wsse.rb
+++ b/lib/akami/wsse.rb
@@ -155,7 +155,12 @@ module Akami
         "wsse:Security" => {
           key => hash
         },
-        :attributes! => { "wsse:Security" => { "xmlns:wsse" => WSE_NAMESPACE } }
+        :attributes! => {
+          "wsse:Security" => {
+            "xmlns:wsse" => WSE_NAMESPACE,
+            "xmlns:wsu" => WSU_NAMESPACE
+          }
+        }
       }
 
       unless extra_info.empty?

--- a/spec/akami/wsse_spec.rb
+++ b/spec/akami/wsse_spec.rb
@@ -108,9 +108,16 @@ describe Akami do
     context "with credentials" do
       before { wsse.credentials "username", "password" }
 
-      it "contains a wsse:Security tag" do
-        namespace = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
-        expect(wsse.to_xml).to include("<wsse:Security xmlns:wsse=\"#{namespace}\">")
+      context "wsse:Security tag" do
+        let(:security_tag) { wsse.to_xml[/<wsse:Security.*?>/] }
+
+        it "contains a xmlns:wsse attribute" do
+          expect(security_tag).to include("xmlns:wsse=\"#{Akami::WSSE::WSE_NAMESPACE}\"")
+        end
+
+        it "contains a xmlns:wsu attribute" do
+          expect(security_tag).to include("xmlns:wsu=\"#{Akami::WSSE::WSU_NAMESPACE}\"")
+        end
       end
 
       it "contains a wsu:Id attribute" do


### PR DESCRIPTION
This was required by an API our team has been integrating with. Monkey-patched this in our codebase, but thought it might be helpful for others.