### PR TITLE
Support for in-memory certificate and private keys

### DIFF
--- a/lib/akami/wsse/certs.rb
+++ b/lib/akami/wsse/certs.rb
@@ -9,16 +9,26 @@ module Akami
         end
       end
 
-      attr_accessor :cert_file, :private_key_file, :private_key_password
+      attr_accessor :cert_file, :cert_string, :private_key_file, :private_key_string, :private_key_password
 
-      # Returns an <tt>OpenSSL::X509::Certificate</tt> for the +cert_file+.
+      # Returns an <tt>OpenSSL::X509::Certificate</tt> for the +cert_string+ or +cert_file+.
       def cert
-        @cert ||= OpenSSL::X509::Certificate.new File.read(cert_file) if cert_file
+        @cert ||=
+          if cert_string.present?
+            OpenSSL::X509::Certificate.new(cert_string)
+          elsif cert_file.present?
+            OpenSSL::X509::Certificate.new(File.read(cert_file))
+          end
       end
 
-      # Returns an <tt>OpenSSL::PKey::RSA</tt> for the +private_key_file+.
+      # Returns an <tt>OpenSSL::PKey::RSA</tt> for the +private_key_string+ or +private_key_file+.
       def private_key
-        @private_key ||= OpenSSL::PKey::RSA.new(File.read(private_key_file), private_key_password) if private_key_file
+        @private_key ||=
+          if private_key_string.present?
+            OpenSSL::PKey::RSA.new(private_key_string, private_key_password)
+          elsif private_key_file.present?
+            OpenSSL::PKey::RSA.new(File.read(private_key_file), private_key_password)
+          end
       end
     end
   end


### PR DESCRIPTION
This PR add support for in-memory certificate and private keys. Since parsing of `cert_file` and `private_key_file` is error prone, the simplest solution is to introduce additional attributes (ending with `_string`) that indicate already present content.