### PR TITLE
Timestamp must precede username token for many systems.

### DIFF
--- a/lib/akami/wsse.rb
+++ b/lib/akami/wsse.rb
@@ -94,7 +94,7 @@ module Akami
       if signature? and signature.have_document?
         Gyoku.xml wsse_signature.merge!(hash)
       elsif username_token? && timestamp?
-        Gyoku.xml wsse_username_token.merge!(wsu_timestamp) {
+        Gyoku.xml wsu_timestamp.merge!(wsse_username_token) {
           |key, v1, v2| v1.merge!(v2) {
             |key, v1, v2| v1.merge!(v2)
           }


### PR DESCRIPTION
We encountered a problem when trying to authenticate to a vendor's SOAP API where the timestamp must precede the username token in order for the request to be verified and authenticated. Otherwise, the follow error is thrown:

``` xml
<?xml version="1.0"?>
<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
  <soap:Body>
    <soap:Fault>
      <faultcode xmlns:ns1="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">ns1:InvalidSecurity</faultcode>
      <faultstring>An error was discovered processing the &lt;wsse:Security&gt; header</faultstring>
    </soap:Fault>
  </soap:Body>
</soap:Envelope>
```

I feel that reversing the order is unlikely to break other implementations, but I would like some feedback on whether this is a change we can/should make. Another, probably less intrusive, option would be to set up a pathway to pass a configuration option through `savon` client instantiation to enforce an order in the WSSE header that `akami` generates.

Thanks, cheers.
