### PR TITLE
Omit gost test case when gost engine isn't supported

### DIFF
--- a/spec/akami/wsse/verify_signature_spec.rb
+++ b/spec/akami/wsse/verify_signature_spec.rb
@@ -1,5 +1,13 @@
 require 'spec_helper'
 
+RSpec.configure do |c|
+  OpenSSL::Engine.load
+  gost_engine = OpenSSL::Engine.engines.select do |engine|
+    engine.id == "gost"
+  end
+  c.filter_run_excluding :omit_gost => gost_engine.empty?
+end
+
 describe Akami::WSSE::VerifySignature do
 
   it 'should validate correctly signed XML messages' do
@@ -40,7 +48,7 @@ describe Akami::WSSE::VerifySignature do
 
   # There is no testing for messages signed with GOST as it requires patched Ruby
   # But we can test GOST digest calculation
-  it 'should validate correctly signed XML messages with RSA-SHA1 signature and GOST R 34.11-94 digests' do
+  it 'should validate correctly signed XML messages with RSA-SHA1 signature and GOST R 34.11-94 digests', :omit_gost => true do
     xml = fixture('akami/wsse/verify_signature/valid_sha1_gost.xml')
     validator = described_class.new(xml)
     expect(validator.verify!).to equal(true)


### PR DESCRIPTION
OpenSSL 1.1.0 or later doesn't contain GOST engine anymore. So, test
should be omitted in such a case.

Without this change, test case fails as follows:

  Failures:

  1) Akami::WSSE::VerifySignature should validate correctly signed XML messages with RSA-SHA1 signature and GOST R 34.11-94 digests
     Failure/Error: expect(validator.verify!).to equal(true)
     OpenSSL::Engine::EngineError:
       no such engine
     # ./lib/akami/wsse/verify_signature.rb:139:in `by_id'
     # ./lib/akami/wsse/verify_signature.rb:139:in `block in <class:VerifySignature>'
     # ./lib/akami/wsse/verify_signature.rb:151:in `digester'
     # ./lib/akami/wsse/verify_signature.rb:112:in `digest'
     # ./lib/akami/wsse/verify_signature.rb:93:in `generate_digest'
     # ./lib/akami/wsse/verify_signature.rb:72:in `block in verify'
     # ./lib/akami/wsse/verify_signature.rb:68:in `verify'
     # ./lib/akami/wsse/verify_signature.rb:48:in `verify!'
     # ./spec/akami/wsse/verify_signature_spec.rb:55:in `block (2 levels) in <top (required)>'