### PR TITLE
Allow rubinius failures in test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,9 @@ rvm:
   - 2.3.0
   - jruby
   - rbx-2
+matrix:
+  allow_failures:
+    - rvm: rbx-2
+  fast_finish: true
 notifications:
   irc: "irc.freenode.org#savon"


### PR DESCRIPTION
The most recent merge to master broke the build spontaneously, because of an incompatibility between akami (which hasn't had a release in several years) and rubinius, which is under active development, and makes it somewhat difficult to lock to a specific version. 

Similar to https://github.com/savonrb/savon/pull/686 I believe rubinius should be tested, but not be considered part of the build status, as there is no one to maintain the test suite for rbx.