### PR TITLE
Add rvm 2.{4,5,6} to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,12 @@ script: "bundle exec rake"
 sudo: false
 rvm:
   - 2.0.0
-  - 2.1.8
-  - 2.2.4
-  - 2.3.0
+  - 2.1.10
+  - 2.2.10
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
+  - 2.6.1
   - jruby
   - rbx-2
 matrix:


### PR DESCRIPTION
Adds recent Ruby releases to the Travis config, and updates all versions to the latest patch releases.