### PR TITLE
gemspec: Drop old property rubyforge_project

### DIFF
--- a/akami.gemspec
+++ b/akami.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
   s.description = "Building Web Service Security"
   s.required_ruby_version = '>= 1.9.2'
 
-  s.rubyforge_project = s.name
   s.license = "MIT"
 
   s.add_dependency "gyoku", ">= 0.4.0"


### PR DESCRIPTION
This can cause a deprecation warning, and is ignored by RubyGems.org.

The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* rubygems/rubygems#2436 deprecated the `rubyforge_project` property

[1]: https://twitter.com/evanphx/status/399552820380053505