### PR TITLE
gemspec: Drop unused directives

### DIFF
--- a/akami.gemspec
+++ b/akami.gemspec
@@ -22,7 +22,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "timecop", "~> 0.5"
 
   s.files = Dir["lib/**/*"] + %w[CHANGELOG.md LICENSE README.md]
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 end


### PR DESCRIPTION
`test_files` is unused in RubyGems.org, and this gem exposes no executables.