### PR TITLE
Bring akami's setup to the savonrb standard

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Create a bug report
+
+---
+
+<!-- Please don't delete this template or we'll close your issue -->
+<!-- Before creating an issue, please ensure you are using the latest version of akami. -->
+
+# Bug report
+
+**Current behavior:**
+
+
+**Akami::WSSE configuration and the XML you got back:**
+
+<!-- The credentials/timestamp/signature options you set on the WSSE object and the XML string `to_xml` returned. -->
+
+**Expected behavior:**
+
+<!-- The wsse header XML you expected instead. -->
+
+**Steps to reproduce current behavior:**
+
+
+**System information:**
+
+* ruby version: 
+* akami version: 

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,0 +1,26 @@
+---
+name: Feature request
+about: Suggest a new feature for akami
+
+---
+
+<!-- Please don't delete this template or we'll close your issue -->
+
+## Feature request
+
+<!-- Issues which contain questions or support requests will be closed. -->
+
+**Motivation for this feature:**
+
+<!-- Please describe the use case or problem this would solve. -->
+
+**Proposed implementation:**
+
+<!-- Please describe at least one proposed implementation design. -->
+
+**Would this introduce a breaking change?**
+
+<!-- If yes, please describe the impact and a migration path for existing applications. -->
+
+**Are you willing to work on this yourself?**
+yes

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+**What kind of change is this?**
+
+<!-- E.g. a bugfix, feature, refactoring, build change, etc… -->
+
+**Did you add tests for your changes?**
+
+<!-- Note that we won't merge your changes if you don't add tests -->
+
+**Summary of changes**
+
+<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
+<!-- Try to link to an open issue for more information. -->
+
+**Other information**

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,14 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for more information:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-# https://containers.dev/guide/dependabot
-
 version: 2
 updates:
- - package-ecosystem: "devcontainers"
-   directory: "/"
-   schedule:
-     interval: weekly
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
     # jruby is included provisionally: akami's OpenSSL-based signing and GOST
     # engine make its jruby support unverified, so it does not block either
     # until a green run proves it can be promoted to a required build.
-    continue-on-error: ${{ matrix.ruby == 'head' || matrix.ruby == 'truffleruby-head' || matrix.ruby == 'jruby-9.4.8' }}
+    continue-on-error: ${{ matrix.ruby == 'head' || matrix.ruby == 'truffleruby-head' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,24 +1,86 @@
-name: Ruby
+name: CI
 
 on:
   - push
   - pull_request
 
+permissions:
+  contents: read # checkout only, nothing else
+
 jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+      - name: Audit dependencies
+        run: bundle exec bundle-audit check --update
+      - name: Audit Ruby runtime
+        # CVE-2026-41316 is an ERB flaw fixed in Ruby 4.0.3 and not yet backported.
+        # Ignored on affected rubies only. See:
+        # https://www.ruby-lang.org/en/news/2026/04/21/erb-cve-2026-41316/
+        # https://github.com/advisories/GHSA-q339-8rmv-2mhv
+        run: |
+          ignore=""
+          if ruby -e 'exit 1 unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new("4.0.3")'; then
+            ignore="--ignore CVE-2026-41316"
+          fi
+          bundle exec ruby-audit check $ignore
+
+  zizmor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Audit workflows
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          advanced-security: false # fail the build on findings instead of uploading SARIF
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+      - name: Standard
+        run: bundle exec standardrb
+
   test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        ruby: [3.0, 3.1, 3.2, 3.3, head, truffleruby-head]
-    env:
-      RAILS_ENV: test
+        ruby: ['3.0', 3.1, 3.2, 3.3, 3.4, '4.0', truffleruby, head, truffleruby-head, jruby-9.4.8]
+    # Head builds surface upstream regressions early and should not block.
+    # jruby is included provisionally: akami's OpenSSL-based signing and GOST
+    # engine make its jruby support unverified, so it does not block either
+    # until a green run proves it can be promoted to a required build.
+    continue-on-error: ${{ matrix.ruby == 'head' || matrix.ruby == 'truffleruby-head' || matrix.ruby == 'jruby-9.4.8' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true # bundle installs and caches dependencies
       - name: Run tests
         run: bundle exec rake --trace
+      - name: Upload coverage to Coveralls
+        if: matrix.ruby == '3.4'
+        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7
+        with:
+          file: coverage/.resultset.json
+          format: simplecov

--- a/.github/workflows/gem_push.yml
+++ b/.github/workflows/gem_push.yml
@@ -1,0 +1,22 @@
+name: Push gem
+on:
+  release:
+    types: [published]
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    environment: release
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
+        with:
+          ruby-version: "3"
+          bundler-cache: false
+      - name: Install dependencies
+        run: bundle install
+      - uses: rubygems/release-gem@052cc82692552de3ef2b81fd670e41d13cba8092 # v1.4.0

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,0 +1,9 @@
+# The WS-Security algorithm/type URIs are public constants named in CamelCase
+# since akami 1.1.0 (2012). They are part of Akami::WSSE::Signature's public
+# surface and are referenced elsewhere as e.g.
+# Akami::WSSE::Signature::ExclusiveXMLCanonicalizationAlgorithm. Renaming them to
+# SCREAMING_SNAKE_CASE would break any caller that references them, so the naming
+# cop is disabled for this one file rather than changing the API.
+ignore:
+  - "lib/akami/wsse/signature.rb":
+      - Naming/ConstantName

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contribution Guide
+
+This page describes how to contribute changes to Akami.
+
+Please do not create a pull request without reading this guide first.
+
+**Bug fixes**
+
+Akami builds WS-Security (wsse) headers for SOAP requests. If you think you found a bug,
+the most useful input you can give us is: how you configured the `Akami::WSSE` object (the
+credentials, timestamp, or signature options you set), the XML you got back from `to_xml`,
+and the XML you expected. You're a developer, we are developers, and you know we need a
+test to reproduce a problem and make sure it does not come back.
+
+So if you can reproduce your problem in a spec, that would be awesome! Please include the
+options you set, because the header output depends on them (`credentials`, `timestamp`,
+`created_at`, `expires_at`, `sign_with`, and friends).
+
+After we have a failing spec, it needs to be fixed. Make sure your new spec is the only
+failing one under the `spec` directory.
+
+**Running tests**
+
+```bash
+bundle install
+bundle exec rspec
+```
+
+Before opening a pull request, also run the checks CI runs so you don't get a red build:
+
+```bash
+bundle exec standardrb
+```
+
+Please follow this workflow for Pull Requests:
+
+* [Fork the project](https://help.github.com/articles/fork-a-repo)
+* Create a feature branch and make your bug fix
+* Add tests for it!
+* [Send a Pull Request](https://help.github.com/articles/using-pull-requests)
+* [Check that your Pull Request passes the build](https://github.com/savonrb/akami/actions/workflows/ci.yml)
+
+**Improvements and feature requests**
+
+If you have an idea for an improvement or a new feature, please feel free to
+[create a new Issue](https://github.com/savonrb/akami/issues/new/choose) and describe your idea
+so that other people can give their insights and opinions. This is also important to avoid
+duplicate work.
+
+Pull Requests and Issues on GitHub are meant to be used to discuss problems and ideas, so please
+make sure to participate and follow up on questions. In case no one comments on your ticket,
+please keep updating the ticket with additional information.

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 gemspec
 
-
+gem "standard", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,8 @@
 source "https://rubygems.org"
 gemspec
 
+gem "bundler-audit", "~> 0.9.3", require: false
+# ruby_audit 3.x requires Ruby >= 3.1. Only the CI audit job needs it.
+gem "ruby_audit", "~> 3.1", require: false if RUBY_VERSION >= "3.1.0"
+gem "simplecov", require: false
 gem "standard", require: false

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,19 @@
+_You'll need write access to the repository to create a release. Publishing is handled automatically via [trusted publishing](https://guides.rubygems.org/trusted-publishing/)._
+
+## Cutting a release
+
+1. On your release branch (e.g. `main`), edit [CHANGELOG.md](https://github.com/savonrb/akami/blob/main/CHANGELOG.md) to finalize the new version number and list of all changes.
+2. Bump [version.rb](https://github.com/savonrb/akami/blob/main/lib/akami/version.rb) to the version you picked in previous step.
+3. **Final check**: make sure all tests are green, and that `rake build` succeeds. If not, merge any fixes back to the release branch and go to step 1.
+4. [Draft a new release](https://github.com/savonrb/akami/releases/new) on Github.
+   - In the "Choose a tag" field, type the version tag - e.g. `v1.3.4` - and select "Create new tag on publish".
+   - Use `v[version]` for the release title, and copy the changelog into the release notes.
+   - Click "Publish release". Github creates and pushes the tag, which triggers the release workflow.
+5. Publishing to RubyGems.org is fully automated. The [Push gem workflow](https://github.com/savonrb/akami/actions/workflows/gem_push.yml) triggers on the published release and requires approval from a release manager via the `release` environment before credentials are issued. **Before approving**: confirm that CI is green on the release commit. Approve the deployment in the Actions UI and the gem will be built and pushed automatically.
+
+## Updating minimum ruby version
+
+- Update `required_ruby_version` in [akami.gemspec](https://github.com/savonrb/akami/blob/main/akami.gemspec)
+- Update the test matrix in [ci.yml](https://github.com/savonrb/akami/blob/main/.github/workflows/ci.yml)
+- Update [README](https://github.com/savonrb/akami/blob/main/README.md) with the correct support matrix
+- Note the updated requirement in [CHANGELOG.md](https://github.com/savonrb/akami/blob/main/CHANGELOG.md)

--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,11 @@
-require 'bundler'
+require "bundler"
 Bundler::GemHelper.install_tasks
 
 require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new do |t|
-  t.rspec_opts = %w(-c)
+  t.rspec_opts = %w[-c]
 end
 
-task :default => :spec
-task :test => :spec
+task default: :spec
+task test: :spec

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are released for the latest 1.x release.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.3.x   | :white_check_mark: |
+| < 1.3   | :x:                |
+
+If you are on an older release, upgrade to the latest 1.x before reporting.
+
+## Reporting a vulnerability
+
+Please do not report security issues through public GitHub issues.
+
+Instead, [report a vulnerability privately](https://github.com/savonrb/akami/security/advisories/new)
+through GitHub. You will get an acknowledgement within 7 days. Please keep the
+report confidential until a fix is released.
+
+## Scope
+
+This policy covers the akami gem, which builds WS-Security (wsse) headers for
+the savon SOAP client. For issues in another gem in the family (gyoku, httpi,
+nori, savon, wasabi), report to the affected repository in the
+[savonrb organization](https://github.com/savonrb). If you are not sure which
+gem is affected, report it here.

--- a/akami.gemspec
+++ b/akami.gemspec
@@ -1,16 +1,15 @@
-# -*- encoding: utf-8 -*-
 $:.push File.expand_path("../lib", __FILE__)
 require "akami/version"
 
 Gem::Specification.new do |s|
-  s.name        = "akami"
-  s.version     = Akami::VERSION
-  s.authors     = ["Daniel Harrington"]
-  s.email       = ["me@rubiii.com"]
-  s.homepage    = "https://github.com/savonrb/#{s.name}"
-  s.summary     = "Web Service Security"
+  s.name = "akami"
+  s.version = Akami::VERSION
+  s.authors = ["Daniel Harrington"]
+  s.email = ["me@rubiii.com"]
+  s.homepage = "https://github.com/savonrb/#{s.name}"
+  s.summary = "Web Service Security"
   s.description = "Building Web Service Security"
-  s.required_ruby_version = '>= 3.0.0'
+  s.required_ruby_version = ">= 3.0.0"
 
   s.license = "MIT"
 
@@ -18,11 +17,11 @@ Gem::Specification.new do |s|
   s.add_dependency "nokogiri"
   s.add_dependency "base64"
 
-  s.add_development_dependency "rake",    "~> 13.0"
-  s.add_development_dependency "rspec",   "~> 3.12"
+  s.add_development_dependency "rake", "~> 13.0"
+  s.add_development_dependency "rspec", "~> 3.12"
   s.add_development_dependency "timecop", "~> 0.5"
 
-  s.metadata = { "rubygems_mfa_required" => "true" }
+  s.metadata = {"rubygems_mfa_required" => "true"}
 
   s.files = Dir["lib/**/*"] + %w[CHANGELOG.md LICENSE README.md]
   s.require_paths = ["lib"]

--- a/lib/akami.rb
+++ b/lib/akami.rb
@@ -2,10 +2,8 @@ require "akami/version"
 require "akami/wsse"
 
 module Akami
-
   # Returns a new <tt>Akami::WSSE</tt>.
   def self.wsse
     WSSE.new
   end
-
 end

--- a/lib/akami/hash_helper.rb
+++ b/lib/akami/hash_helper.rb
@@ -3,9 +3,9 @@ module Akami
     # Returns a new Hash with +hash+ and +other_hash+ merged recursively.
     # Modifies +hash+ in place.
     def self.deep_merge!(hash, other_hash)
-      other_hash.each_pair do |k,v|
+      other_hash.each_pair do |k, v|
         tv = hash[k]
-        hash[k] = tv.is_a?(Hash) && v.is_a?(Hash) ? deep_merge!(tv.dup, v) : v
+        hash[k] = (tv.is_a?(Hash) && v.is_a?(Hash)) ? deep_merge!(tv.dup, v) : v
       end
       hash
     end

--- a/lib/akami/version.rb
+++ b/lib/akami/version.rb
@@ -1,5 +1,3 @@
 module Akami
-
-  VERSION = '1.3.3'
-
+  VERSION = "1.3.3"
 end

--- a/lib/akami/wsse.rb
+++ b/lib/akami/wsse.rb
@@ -9,12 +9,10 @@ require "akami/wsse/verify_signature"
 require "akami/wsse/signature"
 
 module Akami
-
   # = Akami::WSSE
   #
   # Building Web Service Security.
   class WSSE
-
     # Namespace for WS Security Secext.
     WSE_NAMESPACE = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
 
@@ -94,11 +92,11 @@ module Akami
       h = merge_hashes_with_keys(h, wsu_timestamp) if timestamp?
       h = merge_hashes_with_keys(h, wsse_username_token) if username_token?
 
-      return '' unless h
+      return "" unless h
       Gyoku.xml h
     end
 
-  private
+    private
 
     def merge_hashes_with_keys(hash_one, hash_two)
       return hash_two unless hash_one
@@ -116,14 +114,14 @@ module Akami
           "wsse:Nonce" => Base64.encode64(nonce).chomp,
           "wsu:Created" => timestamp,
           "wsse:Password" => digest_password,
-          :attributes! => { "wsse:Password" => { "Type" => PASSWORD_DIGEST_URI },  "wsse:Nonce" => { "EncodingType" => BASE64_URI } }
+          :attributes! => {"wsse:Password" => {"Type" => PASSWORD_DIGEST_URI}, "wsse:Nonce" => {"EncodingType" => BASE64_URI}}
         # clear the nonce after each use
         @nonce = nil
       else
         token = security_hash :wsse, "UsernameToken",
           "wsse:Username" => username,
           "wsse:Password" => password,
-          :attributes! => { "wsse:Password" => { "Type" => PASSWORD_TEXT_URI } }
+          :attributes! => {"wsse:Password" => {"Type" => PASSWORD_TEXT_URI}}
       end
       token
     end
@@ -146,7 +144,7 @@ module Akami
 
     # Returns a Hash containing wsse/wsu Security details for a given
     # +namespace+, +tag+ and +hash+.
-    def security_hash(namespace, tag, hash, extra_info = {}, signature_request=false)
+    def security_hash(namespace, tag, hash, extra_info = {}, signature_request = false)
       key = [namespace, tag].compact.join(":")
 
       sec_hash = {
@@ -154,15 +152,15 @@ module Akami
           key => hash,
           :order! => [key]
         },
-        :attributes! => { "wsse:Security" => { "xmlns:wsse" => WSE_NAMESPACE } }
+        :attributes! => {"wsse:Security" => {"xmlns:wsse" => WSE_NAMESPACE}}
       }
 
       sec_hash["wsse:Security"].merge!(extra_info) unless extra_info.empty?
 
       if signature_request
-        sec_hash[:attributes!].merge!("soapenv:mustUnderstand" => "1")
+        sec_hash[:attributes!]["soapenv:mustUnderstand"] = "1"
       else
-        sec_hash["wsse:Security"].merge!(:attributes! => { key => { "wsu:Id" => "#{tag}-#{count}", "xmlns:wsu" => WSU_NAMESPACE } })
+        sec_hash["wsse:Security"][:attributes!] = {key => {"wsu:Id" => "#{tag}-#{count}", "xmlns:wsu" => WSU_NAMESPACE}}
       end
 
       sec_hash

--- a/lib/akami/wsse/certs.rb
+++ b/lib/akami/wsse/certs.rb
@@ -2,10 +2,9 @@ module Akami
   class WSSE
     # Contains certs for WSSE::Signature
     class Certs
-
       def initialize(certs = {})
         certs.each do |key, value|
-          self.send :"#{key}=", value
+          send :"#{key}=", value
         end
       end
 

--- a/lib/akami/wsse/signature.rb
+++ b/lib/akami/wsse/signature.rb
@@ -23,14 +23,14 @@ module Akami
         @document = Nokogiri::XML(document)
       end
 
-      ExclusiveXMLCanonicalizationAlgorithm = 'http://www.w3.org/2001/10/xml-exc-c14n#'.freeze
-      RSASHA1SignatureAlgorithm = 'http://www.w3.org/2000/09/xmldsig#rsa-sha1'.freeze
-      SHA1DigestAlgorithm = 'http://www.w3.org/2000/09/xmldsig#sha1'.freeze
+      ExclusiveXMLCanonicalizationAlgorithm = "http://www.w3.org/2001/10/xml-exc-c14n#".freeze
+      RSASHA1SignatureAlgorithm = "http://www.w3.org/2000/09/xmldsig#rsa-sha1".freeze
+      SHA1DigestAlgorithm = "http://www.w3.org/2000/09/xmldsig#sha1".freeze
 
-      X509v3ValueType = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3'.freeze
-      Base64EncodingType = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary'.freeze
+      X509v3ValueType = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3".freeze
+      Base64EncodingType = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary".freeze
 
-      SignatureNamespace = 'http://www.w3.org/2000/09/xmldsig#'.freeze
+      SignatureNamespace = "http://www.w3.org/2000/09/xmldsig#".freeze
 
       def initialize(certs = Certs.new)
         @certs = certs
@@ -57,7 +57,7 @@ module Akami
       def body_attributes
         {
           "xmlns:wsu" => Akami::WSSE::WSU_NAMESPACE,
-          "wsu:Id" => body_id,
+          "wsu:Id" => body_id
         }
       end
 
@@ -65,20 +65,20 @@ module Akami
         return {} unless have_document?
 
         sig = signed_info.merge(key_info).merge(signature_value)
-        sig.merge! :order! => []
-        [ "SignedInfo", "SignatureValue", "KeyInfo" ].each do |key|
+        sig[:order!] = []
+        ["SignedInfo", "SignatureValue", "KeyInfo"].each do |key|
           sig[:order!] << key if sig[key]
         end
 
         token = {
           "Signature" => sig,
-          :attributes! => { "Signature" => { "xmlns" => SignatureNamespace } },
+          :attributes! => {"Signature" => {"xmlns" => SignatureNamespace}}
         }
 
         Akami::HashHelper.deep_merge!(token, binary_security_token) if certs.cert
 
-        token.merge! :order! => []
-        [ "wsse:BinarySecurityToken", "Signature" ].each do |key|
+        token[:order!] = []
+        ["wsse:BinarySecurityToken", "Signature"].each do |key|
           token[:order!] << key if token[key]
         end
 
@@ -89,13 +89,13 @@ module Akami
 
       def binary_security_token
         {
-          "wsse:BinarySecurityToken" => Base64.encode64(certs.cert.to_der).gsub("\n", ''),
-          :attributes! => { "wsse:BinarySecurityToken" => {
+          "wsse:BinarySecurityToken" => Base64.encode64(certs.cert.to_der).delete("\n"),
+          :attributes! => {"wsse:BinarySecurityToken" => {
             "wsu:Id" => security_token_id,
-            'EncodingType' => Base64EncodingType,
-            'ValueType' => X509v3ValueType,
-            "xmlns:wsu" => Akami::WSSE::WSU_NAMESPACE,
-          } }
+            "EncodingType" => Base64EncodingType,
+            "ValueType" => X509v3ValueType,
+            "xmlns:wsu" => Akami::WSSE::WSU_NAMESPACE
+          }}
         }
       end
 
@@ -104,18 +104,18 @@ module Akami
           "KeyInfo" => {
             "wsse:SecurityTokenReference" => {
               "wsse:Reference/" => nil,
-              :attributes! => { "wsse:Reference/" => {
+              :attributes! => {"wsse:Reference/" => {
                 "ValueType" => X509v3ValueType,
-                "URI" => "##{security_token_id}",
-              } }
+                "URI" => "##{security_token_id}"
+              }}
             },
-            :attributes! => { "wsse:SecurityTokenReference" => { "xmlns:wsu" => "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" } },
-          },
+            :attributes! => {"wsse:SecurityTokenReference" => {"xmlns:wsu" => "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"}}
+          }
         }
       end
 
       def signature_value
-        { "SignatureValue" => the_signature }
+        {"SignatureValue" => the_signature}
       rescue MissingCertificate
         {}
       end
@@ -126,16 +126,16 @@ module Akami
             "CanonicalizationMethod/" => nil,
             "SignatureMethod/" => nil,
             "Reference" => [
-              #signed_info_transforms.merge(signed_info_digest_method).merge({ "DigestValue" => timestamp_digest }),
-              signed_info_transforms.merge(signed_info_digest_method).merge({ "DigestValue" => body_digest }),
+              # signed_info_transforms.merge(signed_info_digest_method).merge({ "DigestValue" => timestamp_digest }),
+              signed_info_transforms.merge(signed_info_digest_method).merge({"DigestValue" => body_digest})
             ],
             :attributes! => {
-              "CanonicalizationMethod/" => { "Algorithm" => ExclusiveXMLCanonicalizationAlgorithm },
-              "SignatureMethod/" => { "Algorithm" => RSASHA1SignatureAlgorithm },
-              "Reference" => { "URI" => ["##{body_id}"] },
+              "CanonicalizationMethod/" => {"Algorithm" => ExclusiveXMLCanonicalizationAlgorithm},
+              "SignatureMethod/" => {"Algorithm" => RSASHA1SignatureAlgorithm},
+              "Reference" => {"URI" => ["##{body_id}"]}
             },
-            :order! => [ "CanonicalizationMethod/", "SignatureMethod/", "Reference" ],
-          },
+            :order! => ["CanonicalizationMethod/", "SignatureMethod/", "Reference"]
+          }
         }
       end
 
@@ -143,8 +143,8 @@ module Akami
         raise MissingCertificate, "Expected a private_key for signing" unless certs.private_key
         signed_info = at_xpath(@document, "//Envelope/Header/Security/Signature/SignedInfo")
         signed_info = signed_info ? canonicalize(signed_info) : ""
-        signature = certs.private_key.sign(OpenSSL::Digest::SHA1.new, signed_info)
-        Base64.encode64(signature).gsub("\n", '') # TODO: DRY calls to Base64.encode64(...).gsub("\n", '')
+        signature = certs.private_key.sign(OpenSSL::Digest.new("SHA1"), signed_info)
+        Base64.encode64(signature).delete("\n") # TODO: DRY calls to Base64.encode64(...).gsub("\n", '')
       end
 
       def body_digest
@@ -153,15 +153,15 @@ module Akami
       end
 
       def signed_info_digest_method
-        { "DigestMethod/" => nil, :attributes! => { "DigestMethod/" => { "Algorithm" => SHA1DigestAlgorithm } } }
+        {"DigestMethod/" => nil, :attributes! => {"DigestMethod/" => {"Algorithm" => SHA1DigestAlgorithm}}}
       end
 
       def signed_info_transforms
-        { "Transforms" => { "Transform/" => nil, :attributes! => { "Transform/" => { "Algorithm" => ExclusiveXMLCanonicalizationAlgorithm } } } }
+        {"Transforms" => {"Transform/" => nil, :attributes! => {"Transform/" => {"Algorithm" => ExclusiveXMLCanonicalizationAlgorithm}}}}
       end
 
       def uid
-        OpenSSL::Digest::SHA1.hexdigest([Time.now, rand].collect(&:to_s).join('/'))
+        OpenSSL::Digest::SHA1.hexdigest([Time.now, rand].join("/"))
       end
     end
   end

--- a/lib/akami/wsse/verify_signature.rb
+++ b/lib/akami/wsse/verify_signature.rb
@@ -1,5 +1,5 @@
-require 'nokogiri'
-require 'openssl'
+require "nokogiri"
+require "openssl"
 
 module Akami
   class WSSE
@@ -22,9 +22,9 @@ module Akami
       def namespaces
         @namespaces ||= {
           wse: Akami::WSSE::WSE_NAMESPACE,
-          ds:  'http://www.w3.org/2000/09/xmldsig#',
+          ds: "http://www.w3.org/2000/09/xmldsig#",
           wsu: Akami::WSSE::WSU_NAMESPACE,
-          ec:  Akami::WSSE::Signature::ExclusiveXMLCanonicalizationAlgorithm,
+          ec: Akami::WSSE::Signature::ExclusiveXMLCanonicalizationAlgorithm
         }
       end
 
@@ -33,7 +33,7 @@ module Akami
 
       # Returns signer's certificate, bundled in signed document
       def certificate
-        certificate_value = document.at_xpath('//wse:Security/wse:BinarySecurityToken', namespaces).text.strip
+        certificate_value = document.at_xpath("//wse:Security/wse:BinarySecurityToken", namespaces).text.strip
         OpenSSL::X509::Certificate.new Base64.decode64(certificate_value)
       end
 
@@ -41,7 +41,7 @@ module Akami
       def valid?
         verify
       rescue InvalidDigest, InvalidSignedValue
-        return false
+        false
       end
 
       # Validates document signature and digests and raises if anything mismatches.
@@ -59,30 +59,28 @@ module Akami
       #
       #   digesters['http://www.w3.org/2001/04/xmldsig-more#rsa-sha512'] = OpenSSL::Digest::SHA512.new
 
-      def digesters
-        @digesters
-      end
+      attr_reader :digesters
 
       private
 
       def verify
-        document.xpath('//wse:Security/ds:Signature/ds:SignedInfo/ds:Reference', namespaces).each do |ref|
-          digest_algorithm = ref.at_xpath('//ds:DigestMethod', namespaces)['Algorithm']
+        document.xpath("//wse:Security/ds:Signature/ds:SignedInfo/ds:Reference", namespaces).each do |ref|
+          digest_algorithm = ref.at_xpath("//ds:DigestMethod", namespaces)["Algorithm"]
 
-          transform_inclusive_ns = inclusive_namespaces(ref, './/ds:Transforms/ds:Transform/ec:InclusiveNamespaces')
+          transform_inclusive_ns = inclusive_namespaces(ref, ".//ds:Transforms/ds:Transform/ec:InclusiveNamespaces")
 
-          element_id = ref.attributes['URI'].value[1..-1] # strip leading '#'
+          element_id = ref.attributes["URI"].value[1..] # strip leading '#'
           element = document.at_xpath(%(//*[@wsu:Id="#{element_id}"]), namespaces)
           unless supplied_digest(element) == generate_digest(element, digest_algorithm, transform_inclusive_ns)
             raise InvalidDigest, "Invalid Digest for #{element_id}"
           end
         end
 
-        canonicalization_inclusive_ns = inclusive_namespaces(document, '//ds:CanonicalizationMethod/ec:InclusiveNamespaces')
+        canonicalization_inclusive_ns = inclusive_namespaces(document, "//ds:CanonicalizationMethod/ec:InclusiveNamespaces")
 
         data = canonicalize(signed_info, canonicalization_inclusive_ns)
         signature = Base64.decode64(signature_value)
-        signature_algorithm = document.at_xpath('//wse:Security/ds:Signature/ds:SignedInfo/ds:SignatureMethod', namespaces)['Algorithm']
+        signature_algorithm = document.at_xpath("//wse:Security/ds:Signature/ds:SignedInfo/ds:SignatureMethod", namespaces)["Algorithm"]
         signature_digester = digester_for_signature_method(signature_algorithm)
 
         certificate.public_key.verify(signature_digester, signature, data) or raise InvalidSignedValue, "Could not verify the signature value"
@@ -90,11 +88,11 @@ module Akami
 
       def inclusive_namespaces(ref, xpath)
         inclusive_namespaces_element = ref.at_xpath(xpath, namespaces)
-        inclusive_namespaces_element['PrefixList'].split if inclusive_namespaces_element
+        inclusive_namespaces_element["PrefixList"].split if inclusive_namespaces_element
       end
 
       def signed_info
-        document.at_xpath('//wse:Security/ds:Signature/ds:SignedInfo', namespaces)
+        document.at_xpath("//wse:Security/ds:Signature/ds:SignedInfo", namespaces)
       end
 
       # Generate digest for a given +element+ (or its XPath) with a given +algorithm+
@@ -106,11 +104,11 @@ module Akami
 
       def supplied_digest(element)
         element = document.at_xpath(element, namespaces) if element.is_a? String
-        find_digest_value element.attributes['Id'].value
+        find_digest_value element.attributes["Id"].value
       end
 
       def signature_value
-        element = document.at_xpath('//wse:Security/ds:Signature/ds:SignatureValue', namespaces)
+        element = document.at_xpath("//wse:Security/ds:Signature/ds:SignatureValue", namespaces)
         element ? element.text : ""
       end
 
@@ -126,8 +124,8 @@ module Akami
       # Returns digester for calculating digest for signature verification
       def digester_for_signature_method(algorithm_url)
         signature_digest_mapping = {
-          'http://www.w3.org/2000/09/xmldsig#rsa-sha1' => 'http://www.w3.org/2000/09/xmldsig#sha1',
-          'http://www.w3.org/2001/04/xmldsig-more#gostr34102001-gostr3411' => 'http://www.w3.org/2001/04/xmldsig-more#gostr3411',
+          "http://www.w3.org/2000/09/xmldsig#rsa-sha1" => "http://www.w3.org/2000/09/xmldsig#sha1",
+          "http://www.w3.org/2001/04/xmldsig-more#gostr34102001-gostr3411" => "http://www.w3.org/2001/04/xmldsig-more#gostr3411"
         }
         digest_url = signature_digest_mapping[algorithm_url] || algorithm_url
         digester(digest_url)
@@ -135,23 +133,23 @@ module Akami
 
       # Constructors for known digest calculating objects
       DIGESTERS = {
-          # SHA1
-          'http://www.w3.org/2000/09/xmldsig#sha1' => lambda { OpenSSL::Digest::SHA1.new },
-          # SHA 256
-          'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256' => lambda { OpenSSL::Digest::SHA256.new },
-          # GOST R 34.11-94
-          # You need correctly configured gost engine in your system OpenSSL, requires OpenSSL >= 1.0.0
-          # see https://github.com/openssl/openssl/blob/master/engines/ccgost/README.gost
-          'http://www.w3.org/2001/04/xmldsig-more#gostr3411' => lambda {
-            if defined? JRUBY_VERSION
-              OpenSSL::Digest.new('GOST3411')
-            else
-              OpenSSL::Engine.load
-              gost_engine = OpenSSL::Engine.by_id('gost')
-              gost_engine.set_default(0xFFFF)
-              gost_engine.digest('md_gost94')
-            end
-          },
+        # SHA1
+        "http://www.w3.org/2000/09/xmldsig#sha1" => lambda { OpenSSL::Digest.new("SHA1") },
+        # SHA 256
+        "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" => lambda { OpenSSL::Digest.new("SHA256") },
+        # GOST R 34.11-94
+        # You need correctly configured gost engine in your system OpenSSL, requires OpenSSL >= 1.0.0
+        # see https://github.com/openssl/openssl/blob/master/engines/ccgost/README.gost
+        "http://www.w3.org/2001/04/xmldsig-more#gostr3411" => lambda {
+          if defined? JRUBY_VERSION
+            OpenSSL::Digest.new("GOST3411")
+          else
+            OpenSSL::Engine.load
+            gost_engine = OpenSSL::Engine.by_id("gost")
+            gost_engine.set_default(0xFFFF)
+            gost_engine.digest("md_gost94")
+          end
+        }
       }
 
       # Returns instance of +OpenSSL::Digest+ class, initialized, reset, and ready to calculate new hashes.
@@ -163,7 +161,6 @@ module Akami
         end
         @digesters[url].reset
       end
-
     end
   end
 end

--- a/lib/akami/xpath_helper.rb
+++ b/lib/akami/xpath_helper.rb
@@ -11,7 +11,7 @@ module Akami
     end
 
     def local_name_xpath(xpath)
-      xpath.gsub(%r{([/]*)([A-Za-z]+)([/]*)}) { "#{$1}*[local-name()='#{$2}']#{$3}" }
+      xpath.gsub(%r{(/*)([A-Za-z]+)(/*)}) { "#{$1}*[local-name()='#{$2}']#{$3}" }
     end
   end
 end

--- a/spec/akami/wsse/certs_spec.rb
+++ b/spec/akami/wsse/certs_spec.rb
@@ -1,53 +1,51 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Akami::WSSE::Certs do
-
-  let(:private_key_password) {'password' }
-  let(:cert_string)          { nil }
-  let(:private_key_string)   { nil }
+  let(:private_key_password) { "password" }
+  let(:cert_string) { nil }
+  let(:private_key_string) { nil }
 
   let(:fixtures_path) do
-    File.join(Bundler.root, 'spec', 'fixtures', 'akami', 'wsse', 'signature' )
+    File.join(Bundler.root, "spec", "fixtures", "akami", "wsse", "signature")
   end
 
   let(:subject) do
     Akami::WSSE::Certs.new(
-      cert_file:            cert_file_path,
-      cert_string:          cert_string,
-      private_key_file:     private_key_path,
-      private_key_string:   private_key_string,
-      private_key_password: private_key_password,
+      cert_file: cert_file_path,
+      cert_string: cert_string,
+      private_key_file: private_key_path,
+      private_key_string: private_key_string,
+      private_key_password: private_key_password
     )
   end
 
-  context 'with a path to a certificate and private key' do
-    let(:cert_file_path)   { File.join(fixtures_path, 'cert.pem') }
-    let(:private_key_path) { File.join(fixtures_path, 'private_key') }
+  context "with a path to a certificate and private key" do
+    let(:cert_file_path) { File.join(fixtures_path, "cert.pem") }
+    let(:private_key_path) { File.join(fixtures_path, "private_key") }
 
-    it 'uses the certificate path provided' do
+    it "uses the certificate path provided" do
       expected_certificate = OpenSSL::X509::Certificate.new(File.read(cert_file_path))
       expect(subject.cert.to_pem).to eq(expected_certificate.to_pem)
     end
 
-    it 'uses the private key path provided' do
+    it "uses the private key path provided" do
       expected_key = OpenSSL::PKey::RSA.new(File.read(private_key_path), private_key_password)
       expect(subject.private_key.to_pem).to eq(expected_key.to_pem)
     end
 
-    context 'with an in-memory cert and private key' do
-      let!(:cert_string) { File.read(File.join(fixtures_path, 'cert2.pem')) }
-      let!(:private_key_string) { File.read(File.join(fixtures_path, 'private_key2')) }
+    context "with an in-memory cert and private key" do
+      let!(:cert_string) { File.read(File.join(fixtures_path, "cert2.pem")) }
+      let!(:private_key_string) { File.read(File.join(fixtures_path, "private_key2")) }
 
-      it 'uses the strings provided' do
+      it "uses the strings provided" do
         expected_certificate = OpenSSL::X509::Certificate.new(cert_string).to_pem
         expect(subject.cert.to_pem).to eq(expected_certificate)
       end
 
-      it 'uses the private key provided' do
+      it "uses the private key provided" do
         expected_key = OpenSSL::PKey::RSA.new(private_key_string, private_key_password)
         expect(subject.private_key.to_pem).to eq(expected_key.to_pem)
       end
-
     end
   end
 end

--- a/spec/akami/wsse/signature_spec.rb
+++ b/spec/akami/wsse/signature_spec.rb
@@ -1,41 +1,39 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Akami::WSSE::Signature do
-
   let(:validator) { Akami::WSSE::VerifySignature.new(xml) }
-  let(:xml) { '' }
+  let(:xml) { "" }
 
   let(:fixtures_path) {
-    File.join(Bundler.root, 'spec', 'fixtures', 'akami', 'wsse', 'signature' )
+    File.join(Bundler.root, "spec", "fixtures", "akami", "wsse", "signature")
   }
-  let(:cert_path) { File.join(fixtures_path, 'cert.pem') }
-  let(:password) { 'password' }
+  let(:cert_path) { File.join(fixtures_path, "cert.pem") }
+  let(:password) { "password" }
 
   let(:signature) {
     Akami::WSSE::Signature.new(
       Akami::WSSE::Certs.new(
-        cert_file:            cert_path,
-        private_key_file:     cert_path,
+        cert_file: cert_path,
+        private_key_file: cert_path,
         private_key_password: password
       )
     )
   }
 
-  context 'to_token' do
-    let(:xml) { fixture('akami/wsse/signature/unsigned.xml') }
+  context "to_token" do
+    let(:xml) { fixture("akami/wsse/signature/unsigned.xml") }
 
-    it 'ignores excessive whitespace' do
+    it "ignores excessive whitespace" do
       signature.document = xml
       expect(signature.document).not_to include("  ")
     end
 
-    it 'deep_merges with binary_security_token' do
+    it "deep_merges with binary_security_token" do
       signature.document = xml
-      expect(signature.to_token[:attributes!]['wsse:BinarySecurityToken']['xmlns:wsu']).
-        to equal(Akami::WSSE::WSU_NAMESPACE)
-      expect(signature.to_token[:attributes!]['Signature']['xmlns']).
-        to equal(Akami::WSSE::Signature::SignatureNamespace)
+      expect(signature.to_token[:attributes!]["wsse:BinarySecurityToken"]["xmlns:wsu"])
+        .to equal(Akami::WSSE::WSU_NAMESPACE)
+      expect(signature.to_token[:attributes!]["Signature"]["xmlns"])
+        .to equal(Akami::WSSE::Signature::SignatureNamespace)
     end
   end
-
 end

--- a/spec/akami/wsse/verify_signature_spec.rb
+++ b/spec/akami/wsse/verify_signature_spec.rb
@@ -1,51 +1,50 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Akami::WSSE::VerifySignature do
-
-  it 'validates correctly signed XML messages' do
-    xml = fixture('akami/wsse/verify_signature/valid.xml')
+  it "validates correctly signed XML messages" do
+    xml = fixture("akami/wsse/verify_signature/valid.xml")
     validator = described_class.new(xml)
     expect(validator.verify!).to eq(true)
   end
 
-  it 'validates correctly signed XML messages with differently named namespaces' do
-    xml = fixture('akami/wsse/verify_signature/valid_namespaces.xml')
+  it "validates correctly signed XML messages with differently named namespaces" do
+    xml = fixture("akami/wsse/verify_signature/valid_namespaces.xml")
     validator = described_class.new(xml)
     expect(validator.verify!).to eq(true)
   end
 
-  it 'validates correctly signed XML messages with whitespaces' do
-    xml = fixture('akami/wsse/verify_signature/valid_whitespaces.xml')
+  it "validates correctly signed XML messages with whitespaces" do
+    xml = fixture("akami/wsse/verify_signature/valid_whitespaces.xml")
     validator = described_class.new(xml)
     expect(validator.verify!).to equal(true)
   end
 
-  it 'does not validate signed XML messages with digested content changed' do
-    xml = fixture('akami/wsse/verify_signature/invalid_digested_changed.xml')
+  it "does not validate signed XML messages with digested content changed" do
+    xml = fixture("akami/wsse/verify_signature/invalid_digested_changed.xml")
     validator = described_class.new(xml)
-    expect{ validator.verify! }.to raise_error(Akami::WSSE::InvalidSignature)
+    expect { validator.verify! }.to raise_error(Akami::WSSE::InvalidSignature)
   end
 
-  it 'does not validate signed XML messages with digest changed' do
-    xml = fixture('akami/wsse/verify_signature/invalid_digest_changed.xml')
+  it "does not validate signed XML messages with digest changed" do
+    xml = fixture("akami/wsse/verify_signature/invalid_digest_changed.xml")
     validator = described_class.new(xml)
-    expect{ validator.verify! }.to raise_error(Akami::WSSE::InvalidSignature)
+    expect { validator.verify! }.to raise_error(Akami::WSSE::InvalidSignature)
   end
 
-  it 'does not validate signed XML messages with signature changed' do
-    xml = fixture('akami/wsse/verify_signature/invalid_signature_changed.xml')
+  it "does not validate signed XML messages with signature changed" do
+    xml = fixture("akami/wsse/verify_signature/invalid_signature_changed.xml")
     validator = described_class.new(xml)
-    expect{ validator.verify! }.to raise_error(Akami::WSSE::InvalidSignature)
+    expect { validator.verify! }.to raise_error(Akami::WSSE::InvalidSignature)
   end
 
-  it 'validates correctly signed XML messages with SHA256 signature and SHA256 digests' do
-    xml = fixture('akami/wsse/verify_signature/valid_sha256.xml')
+  it "validates correctly signed XML messages with SHA256 signature and SHA256 digests" do
+    xml = fixture("akami/wsse/verify_signature/valid_sha256.xml")
     validator = described_class.new(xml)
     expect(validator.verify!).to equal(true)
   end
 
-  it 'validates correctly signed XML messages with inclusive namespaces in transforms' do
-    xml = fixture('akami/wsse/verify_signature/valid_with_inclusive_namespaces.xml')
+  it "validates correctly signed XML messages with inclusive namespaces in transforms" do
+    xml = fixture("akami/wsse/verify_signature/valid_with_inclusive_namespaces.xml")
     validator = described_class.new(xml)
     expect(validator.verify!).to equal(true)
   end

--- a/spec/akami/wsse_spec.rb
+++ b/spec/akami/wsse_spec.rb
@@ -1,6 +1,6 @@
-require 'spec_helper'
-require 'base64'
-require 'nokogiri'
+require "spec_helper"
+require "base64"
+require "nokogiri"
 
 describe Akami do
   let(:wsse) { Akami.wsse }
@@ -29,8 +29,8 @@ describe Akami do
     )
   end
 
-  it "contains the namespace for Base64 Encoding type" do 
-    expect(Akami::WSSE::BASE64_URI).to eq( 
+  it "contains the namespace for Base64 Encoding type" do
+    expect(Akami::WSSE::BASE64_URI).to eq(
       "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary"
     )
   end
@@ -108,7 +108,7 @@ describe Akami do
     context "with credentials" do
       before { wsse.credentials "username", "password" }
 
-      it 'contains a wsse:Security tag' do
+      it "contains a wsse:Security tag" do
         expect(wsse.to_xml).to include("<wsse:Security xmlns:wsse=\"#{Akami::WSSE::WSE_NAMESPACE}\">")
       end
 
@@ -185,23 +185,23 @@ describe Akami do
       it "contains a properly hashed password" do
         xml_header = Nokogiri::XML(wsse.to_xml)
         xml_header.remove_namespaces!
-        nonce = Base64.decode64(xml_header.xpath('//Nonce').first.content)
-        created_at = xml_header.xpath('//Created').first.content
-        password_hash = Base64.decode64(xml_header.xpath('//Password').first.content)
-        expect(password_hash).to eq(Digest::SHA1.digest((nonce + created_at + "password")))
+        nonce = Base64.decode64(xml_header.xpath("//Nonce").first.content)
+        created_at = xml_header.xpath("//Created").first.content
+        password_hash = Base64.decode64(xml_header.xpath("//Password").first.content)
+        expect(password_hash).to eq(Digest::SHA1.digest(nonce + created_at + "password"))
       end
     end
 
     context "with a signature" do
-      let(:valid_signature) { fixture('akami/wsse/verify_signature/valid.xml') }
-      let(:cert_path) { File.join(Bundler.root, 'spec', 'fixtures', 'akami', 'wsse', 'signature', 'cert.pem' ) }
-      let(:password) { 'password' }
+      let(:valid_signature) { fixture("akami/wsse/verify_signature/valid.xml") }
+      let(:cert_path) { File.join(Bundler.root, "spec", "fixtures", "akami", "wsse", "signature", "cert.pem") }
+      let(:password) { "password" }
 
       let(:signature) {
         Akami::WSSE::Signature.new(
           Akami::WSSE::Certs.new(
-            cert_file:            cert_path,
-            private_key_file:     cert_path,
+            cert_file: cert_path,
+            private_key_file: cert_path,
             private_key_password: password
           )
         )
@@ -212,54 +212,54 @@ describe Akami do
         wsse.signature.document = valid_signature
       end
 
-      it 'contains a wsse:BinarySecurityToken' do
-        expect(wsse.to_xml).to include('<wsse:BinarySecurityToken')
+      it "contains a wsse:BinarySecurityToken" do
+        expect(wsse.to_xml).to include("<wsse:BinarySecurityToken")
       end
 
-      it 'contains a wsse:Security tag' do
+      it "contains a wsse:Security tag" do
         expect(wsse.to_xml).to include("<wsse:Security xmlns:wsse=\"#{Akami::WSSE::WSE_NAMESPACE}\">")
       end
 
-      it 'contains a wsse:BinarySecurityToken' do
-        binary_security_token = 'MIIDIjCCAougAwIBAgIJAI53JnRgJIJwMA0GCSqGSIb3DQEBBQUAMGoxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1TYW4gRnJhbmNpc2NvMQ4wDAYDVQQKEwVTYXZvbjEOMAwGA1UECxMFU2F2b24xDjAMBgNVBAMTBVNhdm9uMB4XDTE0MTIwMjAwMTMwMloXDTI0MTEyOTAwMTMwMlowajELMAkGA1UEBhMCVVMxEzARBgNVBAgTCkNhbGlmb3JuaWExFjAUBgNVBAcTDVNhbiBGcmFuY2lzY28xDjAMBgNVBAoTBVNhdm9uMQ4wDAYDVQQLEwVTYXZvbjEOMAwGA1UEAxMFU2F2b24wgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAM56hKF3+4SSUu8msb5HWMvp322yQL+luJ+Lt/r/ib7EPeb4UU68b+Wf3xIa3N1+w8tDQghCR4YuEIILKH/UGC785OldVJfikD4kxiwF4jB0RgdRK/JEG/UthHKqJID+oyijW4ws4MgZ/bWMhSbSVRioqcwe2JElg/m2TemKJkXDAgMBAAGjgc8wgcwwHQYDVR0OBBYEFKSd+UicrRDQS2NeLSEAZpipjk8EMIGcBgNVHSMEgZQwgZGAFKSd+UicrRDQS2NeLSEAZpipjk8EoW6kbDBqMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNU2FuIEZyYW5jaXNjbzEOMAwGA1UEChMFU2F2b24xDjAMBgNVBAsTBVNhdm9uMQ4wDAYDVQQDEwVTYXZvboIJAI53JnRgJIJwMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADgYEAWI27+cDx3U53zaJROXKfQutqUZzZz9B0NzQ0vlN2h5UbACGbXH9C1wLzMBvNjgEiK+/jHSadSDgfvADv+2hCsFw8eNgbisWiV5yvDyTqttg3cSJHz8jRDeA+jnvaC9Y//AoRr/WGKKU3FY40J7pQKcQNczGUzCS+ag0IO64agTs='
+      it "contains a wsse:BinarySecurityToken" do
+        binary_security_token = "MIIDIjCCAougAwIBAgIJAI53JnRgJIJwMA0GCSqGSIb3DQEBBQUAMGoxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1TYW4gRnJhbmNpc2NvMQ4wDAYDVQQKEwVTYXZvbjEOMAwGA1UECxMFU2F2b24xDjAMBgNVBAMTBVNhdm9uMB4XDTE0MTIwMjAwMTMwMloXDTI0MTEyOTAwMTMwMlowajELMAkGA1UEBhMCVVMxEzARBgNVBAgTCkNhbGlmb3JuaWExFjAUBgNVBAcTDVNhbiBGcmFuY2lzY28xDjAMBgNVBAoTBVNhdm9uMQ4wDAYDVQQLEwVTYXZvbjEOMAwGA1UEAxMFU2F2b24wgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAM56hKF3+4SSUu8msb5HWMvp322yQL+luJ+Lt/r/ib7EPeb4UU68b+Wf3xIa3N1+w8tDQghCR4YuEIILKH/UGC785OldVJfikD4kxiwF4jB0RgdRK/JEG/UthHKqJID+oyijW4ws4MgZ/bWMhSbSVRioqcwe2JElg/m2TemKJkXDAgMBAAGjgc8wgcwwHQYDVR0OBBYEFKSd+UicrRDQS2NeLSEAZpipjk8EMIGcBgNVHSMEgZQwgZGAFKSd+UicrRDQS2NeLSEAZpipjk8EoW6kbDBqMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNU2FuIEZyYW5jaXNjbzEOMAwGA1UEChMFU2F2b24xDjAMBgNVBAsTBVNhdm9uMQ4wDAYDVQQDEwVTYXZvboIJAI53JnRgJIJwMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADgYEAWI27+cDx3U53zaJROXKfQutqUZzZz9B0NzQ0vlN2h5UbACGbXH9C1wLzMBvNjgEiK+/jHSadSDgfvADv+2hCsFw8eNgbisWiV5yvDyTqttg3cSJHz8jRDeA+jnvaC9Y//AoRr/WGKKU3FY40J7pQKcQNczGUzCS+ag0IO64agTs="
         expect(wsse.to_xml).to include(binary_security_token)
       end
 
-      it 'contains a Signature tag' do
-        namespace = 'http://www.w3.org/2000/09/xmldsig#'
+      it "contains a Signature tag" do
+        namespace = "http://www.w3.org/2000/09/xmldsig#"
         expect(wsse.to_xml).to include("<Signature xmlns=\"#{namespace}\"")
       end
 
-      it 'contains a CanonicalizationMethod tag' do
-        namespace = 'http://www.w3.org/2001/10/xml-exc-c14n#'
+      it "contains a CanonicalizationMethod tag" do
+        namespace = "http://www.w3.org/2001/10/xml-exc-c14n#"
         expect(wsse.to_xml).to include("<CanonicalizationMethod Algorithm=\"#{namespace}\"")
       end
 
-      it 'contains a SignatureMethod tag' do
-        namespace = 'http://www.w3.org/2000/09/xmldsig#rsa-sha1'
+      it "contains a SignatureMethod tag" do
+        namespace = "http://www.w3.org/2000/09/xmldsig#rsa-sha1"
         expect(wsse.to_xml).to include("<SignatureMethod Algorithm=\"#{namespace}\"")
       end
 
-      it 'contains a DigestValue tag' do
-        digest_value = 'YrKqrE99N7hNGYEvrhifL/LaxKQ='
+      it "contains a DigestValue tag" do
+        digest_value = "YrKqrE99N7hNGYEvrhifL/LaxKQ="
         expect(wsse.to_xml).to include("<DigestValue>#{digest_value}</DigestValue>")
       end
 
-      it 'contains a SignatureValue tag' do
-        signature_value = 'MF8Mn/SgQjQICfyfZpYHToubaDAvJG76kiicDYrbXXHdF/Hvwz7+/IfRexlodhBrbuPIWqfbRnfgb65UM4a5hbOu9WbLnz8kuEujcUo3xKczEvkl+kjMOYty7GYaXWTj+6IkNMl9FJ+PGf8QNzD52MwhMOLq5t94WHSB0jDDiIo='
+      it "contains a SignatureValue tag" do
+        signature_value = "MF8Mn/SgQjQICfyfZpYHToubaDAvJG76kiicDYrbXXHdF/Hvwz7+/IfRexlodhBrbuPIWqfbRnfgb65UM4a5hbOu9WbLnz8kuEujcUo3xKczEvkl+kjMOYty7GYaXWTj+6IkNMl9FJ+PGf8QNzD52MwhMOLq5t94WHSB0jDDiIo="
         expect(wsse.to_xml).to include("<SignatureValue>#{signature_value}</SignatureValue>")
       end
 
-      it 'contains a wsse:SecurityTokenReference tag' do
+      it "contains a wsse:SecurityTokenReference tag" do
         expect(wsse.to_xml).to include("<wsse:SecurityTokenReference xmlns:wsu=\"#{Akami::WSSE::WSU_NAMESPACE}\"")
       end
 
-      it 'contains a wsse:Reference tag' do
-        namespace = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3'
+      it "contains a wsse:Reference tag" do
+        namespace = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3"
         expect(wsse.to_xml).to include("<wsse:Reference ValueType=\"#{namespace}\"")
       end
 
-      describe 'with credentials' do
+      describe "with credentials" do
         before { wsse.credentials "username", "password" }
 
         it "contains the username and password" do
@@ -271,21 +271,21 @@ describe Akami do
         end
       end
 
-      describe 'with a timestamp' do
+      describe "with a timestamp" do
         before { wsse.timestamp = true }
 
         it "contains a wsse:Timestamp node" do
-          expect(wsse.to_xml).to include('<wsu:Timestamp wsu:Id="Timestamp-1" ' +
+          expect(wsse.to_xml).to include('<wsu:Timestamp wsu:Id="Timestamp-1" ' \
             "xmlns:wsu=\"#{Akami::WSSE::WSU_NAMESPACE}\">")
         end
-  
+
         it "contains a wsu:Created node defaulting to Time.now" do
           created_at = Time.now
           Timecop.freeze created_at do
             expect(wsse.to_xml).to include("<wsu:Created>#{created_at.utc.xmlschema}</wsu:Created>")
           end
         end
-  
+
         it "contains a wsu:Expires node defaulting to Time.now + 60 seconds" do
           created_at = Time.now
           Timecop.freeze created_at do
@@ -294,7 +294,7 @@ describe Akami do
         end
       end
 
-      describe 'with a timestamp and credentials' do
+      describe "with a timestamp and credentials" do
         before do
           wsse.credentials "username", "password"
           wsse.timestamp = true
@@ -305,7 +305,7 @@ describe Akami do
         end
 
         it "contains a wsse:Timestamp node" do
-          expect(wsse.to_xml).to match(/<wsu:Timestamp wsu:Id=\"Timestamp-\d\" xmlns:wsu=\"#{Akami::WSSE::WSU_NAMESPACE}\">/i)
+          expect(wsse.to_xml).to match(/<wsu:Timestamp wsu:Id="Timestamp-\d" xmlns:wsu="#{Akami::WSSE::WSU_NAMESPACE}">/io)
         end
       end
     end
@@ -314,7 +314,7 @@ describe Akami do
       before { wsse.timestamp = true }
 
       it "contains a wsse:Timestamp node" do
-        expect(wsse.to_xml).to include('<wsu:Timestamp wsu:Id="Timestamp-1" ' +
+        expect(wsse.to_xml).to include('<wsu:Timestamp wsu:Id="Timestamp-1" ' \
           "xmlns:wsu=\"#{Akami::WSSE::WSU_NAMESPACE}\">")
       end
 
@@ -383,5 +383,4 @@ describe Akami do
       end
     end
   end
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,5 +2,5 @@ require "bundler"
 Bundler.require :default, :development
 
 def fixture(local_path)
-  File.read(File.join(File.dirname(__FILE__), 'fixtures', local_path))
+  File.read(File.join(File.dirname(__FILE__), "fixtures", local_path))
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,10 @@
+unless RUBY_PLATFORM.match?(/java/)
+  require "simplecov"
+  SimpleCov.start do
+    add_filter "spec"
+  end
+end
+
 require "bundler"
 Bundler.require :default, :development
 


### PR DESCRIPTION
### Workflows / CI
* SHA-pin every action, drop GITHUB_TOKEN to read-only, and set persist-credentials: false on checkouts
* Add audit (bundle-audit + ruby-audit), zizmor and standardrb jobs
* Extend the test matrix to 3.4/4.0/truffleruby and add a provisional jruby-9.4.8 build
* Upload coverage to Coveralls from the 3.4 build

### Release / RubyGems
* Add gem_push.yml for trusted publishing
* Add RELEASING.md documenting the release flow

### Linting / coverage
* Adopt standardrb

### Dependencies
* dependabot: track the github-actions ecosystem weekly with a 7-day cooldown
* Add bundler-audit, ruby_audit, simplecov and standard to the Gemfile

### Docs / templates
* Add SECURITY.md, CONTRIBUTING.md, issue templates and a PR template