### PR TITLE
Remove unused coveralls GH Action workaround Revert "CI: Ensure the coveralls can run"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Run tests
         run: bundle exec rake --trace
       - name: Upload coverage to Coveralls
-        if: matrix.ruby == '4.0'
+        if: matrix.ruby == '3.4'
         uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
         with:
           file: coverage/.resultset.json

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ gemspec
 gem "bundler-audit", "~> 0.9.3", require: false
 # ruby_audit 3.x requires Ruby >= 3.1. Only the CI audit job needs it.
 gem "ruby_audit", "~> 3.1", require: false if RUBY_VERSION >= "3.1.0"
-gem "simplecov", "< 1.1.0", require: false # simplecov 1.1.0 writes .resultset.json "timestamp" as a float, which the Coveralls reporter rejects (it parses the field as Int64). Unpin once coverallsapp/coverage-reporter accepts floats.
+gem "simplecov", require: false
 gem "standard", require: false


### PR DESCRIPTION

**What kind of change is this?**

The upstream GH Action for coveralls has had an update, beginning support for the simplecov 1.x.

**Did you add tests for your changes?**

I only reverted the <1.x Gemfile.

**Summary of changes**

This reverts commit c59fdffdd73149ca61d74271064f2caa286a92a1.


